### PR TITLE
fix can't override to default version

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ async function checkUpdates() {
 }
 
 async function listToolchains() {
-	let availableToolchains = (await collectStdout(['toolchain', 'list'])).split('\n');
+	let availableToolchains = (await collectStdout(['toolchain', 'list'])).split('\n').map((line) => line.trim().split(' ')[0]);
 	let selected = await vscode.window.showQuickPick(availableToolchains, { "title": "Change active toolchain?" });
 	if (selected && vscode.window.activeTextEditor !== undefined) {
 		let currentWorkspacePath = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)?.uri.fsPath;


### PR DESCRIPTION
when switch to defualt version trigger this error
error: toolchain 'stable-x86_64-pc-windows-msvc (default)' is not installed